### PR TITLE
fix: wildcard not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CCBR_tobias development version
 
+- Fix wildcard not found error. (#10, @kelly-sovacool)
+
 # CCBR_tobias 0.3.0
 
 - Update Biowulf module versions in driver script and snakemake config. (#4, @kelly-sovacool)

--- a/tobias.snakefile
+++ b/tobias.snakefile
@@ -362,7 +362,7 @@ rule create_cont_cond_tf_join_filelist:
 rule bgzip_beds:
     input:
         rules.create_cont_cond_tf_join_filelist.output.tsv,
-        rules.create_network.output # run create_network first
+        [f"{WORKDIR}/network/{contrast}/{conditions_list[0]}/edges.txt" for contrast, conditions_list in CONTRASTS2CONDITIONS.items()] # run create_network first
     output:
         tsv=join(WORKDIR,"TFBS_{contrast}","bound_beds_list.tsv")
     params:


### PR DESCRIPTION
## Changes

Fixes an error reported by Krithika where the `condition` wildcard in network output files couldn't be determined when used as input for the `bgzip_beds` step.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes such as a bug fix, new feature, or any change in behavior.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
